### PR TITLE
Is time travel enabled fix

### DIFF
--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -9,7 +9,6 @@ import { Structure, RouterAction, LocationState } from './types'
 type ConnectedRouterProps = {
   children?: React.ReactNode;
   reducerKey?: string;
-  ignoreInitial?: boolean,
   Router?: SingletonRouter;
 }
 
@@ -23,7 +22,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
    */
   const ConnectedRouter: React.FC<ConnectedRouterProps> = props => {
     const Router = props.Router || NextRouter
-    const { reducerKey = 'router', ignoreInitial = false } = props
+    const { reducerKey = 'router' } = props
     const store = useStore()
     const ongoingRouteChanges = useRef(0)
     const isTimeTravelEnabled = useRef(false)
@@ -36,19 +35,6 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     function trackRouteStart(): void {
       isTimeTravelEnabled.current = ++ongoingRouteChanges.current <= 0
     }
-
-    useEffect(() => {
-      if (!ignoreInitial) {
-        return
-      }
-
-      Router.ready(() => {
-        // Router.ready ensures that Router.router is defined
-        store.dispatch(onLocationChanged(locationFromUrl(Router.asPath), 'REPLACE'))
-      })
-
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
 
     useEffect(() => {
       function listenStoreChanges(): void {

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -9,7 +9,7 @@ import { Structure, RouterAction, LocationState } from './types'
 type ConnectedRouterProps = {
   children?: React.ReactNode;
   reducerKey?: string;
-  isClientSideAutoInitial?: boolean,
+  ignoreInitial?: boolean,
   Router?: SingletonRouter;
 }
 
@@ -23,7 +23,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
    */
   const ConnectedRouter: React.FC<ConnectedRouterProps> = props => {
     const Router = props.Router || NextRouter
-    const { reducerKey = 'router', isClientSideAutoInitial = false } = props
+    const { reducerKey = 'router', ignoreInitial = false } = props
     const store = useStore()
     const ongoingRouteChanges = useRef(0)
     const isTimeTravelEnabled = useRef(false)
@@ -38,18 +38,13 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     }
 
     useEffect(() => {
-      if (!isClientSideAutoInitial) {
-        return
-      }
-
-      if (typeof window === 'undefined') {
+      if (!ignoreInitial) {
         return
       }
 
       Router.ready(() => {
         // Router.ready ensures that Router.router is defined
-        const { pathname } = window.location
-        store.dispatch(onLocationChanged(locationFromUrl(pathname), 'REPLACE'))
+        store.dispatch(onLocationChanged(locationFromUrl(Router.asPath), 'REPLACE'))
       })
 
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -9,7 +9,7 @@ import { Structure, RouterAction, LocationState } from './types'
 type ConnectedRouterProps = {
   children?: React.ReactNode;
   reducerKey?: string;
-  isClientSideAutoInitial?: boolean,
+  clientSideAutosync?: boolean,
   Router?: SingletonRouter;
 }
 
@@ -23,7 +23,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
    */
   const ConnectedRouter: React.FC<ConnectedRouterProps> = props => {
     const Router = props.Router || NextRouter
-    const { reducerKey = 'router', isClientSideAutoInitial = false } = props
+    const { reducerKey = 'router', clientSideAutosync = false } = props
     const store = useStore()
     const ongoingRouteChanges = useRef(0)
     const isTimeTravelEnabled = useRef(false)
@@ -38,7 +38,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     }
 
     useEffect(() => {
-      if (!isClientSideAutoInitial) {
+      if (!clientSideAutosync) {
         return
       }
 
@@ -48,8 +48,15 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
 
       Router.ready(() => {
         // Router.ready ensures that Router.router is defined
-        const { pathname } = window.location
-        store.dispatch(onLocationChanged(locationFromUrl(pathname), 'REPLACE'))
+        const { router }= Router
+        if (!router) {
+          return
+        }
+        const pathname = router.pathname || ''
+        const { location } = window
+        const asPath = `${location.pathname}${location.search}`
+
+        store.dispatch(onLocationChanged(locationFromUrl(pathname, asPath), 'REPLACE'))
       })
 
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -29,11 +29,12 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     const inTimeTravelling = useRef(false)
 
     function trackRouteComplete(): void {
-      isTimeTravelEnabled.current = --ongoingRouteChanges.current <= 0
+      ongoingRouteChanges.current = Math.max(ongoingRouteChanges.current - 1, 0)
+      isTimeTravelEnabled.current = ongoingRouteChanges.current === 0
     }
 
     function trackRouteStart(): void {
-      isTimeTravelEnabled.current = ++ongoingRouteChanges.current <= 0
+      isTimeTravelEnabled.current = ++ongoingRouteChanges.current === 0
     }
 
     useEffect(() => {

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -9,7 +9,7 @@ import { Structure, RouterAction, LocationState } from './types'
 type ConnectedRouterProps = {
   children?: React.ReactNode;
   reducerKey?: string;
-  clientSideAutosync?: boolean,
+  isClientSideAutoInitial?: boolean,
   Router?: SingletonRouter;
 }
 
@@ -23,7 +23,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
    */
   const ConnectedRouter: React.FC<ConnectedRouterProps> = props => {
     const Router = props.Router || NextRouter
-    const { reducerKey = 'router', clientSideAutosync = false } = props
+    const { reducerKey = 'router', isClientSideAutoInitial = false } = props
     const store = useStore()
     const ongoingRouteChanges = useRef(0)
     const isTimeTravelEnabled = useRef(false)
@@ -38,7 +38,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     }
 
     useEffect(() => {
-      if (!clientSideAutosync) {
+      if (!isClientSideAutoInitial) {
         return
       }
 
@@ -48,15 +48,8 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
 
       Router.ready(() => {
         // Router.ready ensures that Router.router is defined
-        const { router }= Router
-        if (!router) {
-          return
-        }
-        const pathname = router.pathname || ''
-        const { location } = window
-        const asPath = `${location.pathname}${location.search}`
-
-        store.dispatch(onLocationChanged(locationFromUrl(pathname, asPath), 'REPLACE'))
+        const { pathname } = window.location
+        store.dispatch(onLocationChanged(locationFromUrl(pathname), 'REPLACE'))
       })
 
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -30,12 +30,11 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     const inTimeTravelling = useRef(false)
 
     function trackRouteComplete(): void {
-      ongoingRouteChanges.current = Math.max(ongoingRouteChanges.current - 1, 0)
-      isTimeTravelEnabled.current = ongoingRouteChanges.current === 0
+      isTimeTravelEnabled.current = --ongoingRouteChanges.current <= 0
     }
 
     function trackRouteStart(): void {
-      isTimeTravelEnabled.current = ++ongoingRouteChanges.current === 0
+      isTimeTravelEnabled.current = ++ongoingRouteChanges.current <= 0
     }
 
     useEffect(() => {

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -9,7 +9,7 @@ import { Structure, RouterAction, LocationState } from './types'
 type ConnectedRouterProps = {
   children?: React.ReactNode;
   reducerKey?: string;
-  ignoreInitial?: boolean,
+  isClientSideAutoInitial?: boolean,
   Router?: SingletonRouter;
 }
 
@@ -23,7 +23,7 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
    */
   const ConnectedRouter: React.FC<ConnectedRouterProps> = props => {
     const Router = props.Router || NextRouter
-    const { reducerKey = 'router', ignoreInitial = false } = props
+    const { reducerKey = 'router', isClientSideAutoInitial = false } = props
     const store = useStore()
     const ongoingRouteChanges = useRef(0)
     const isTimeTravelEnabled = useRef(false)
@@ -38,13 +38,18 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     }
 
     useEffect(() => {
-      if (!ignoreInitial) {
+      if (!isClientSideAutoInitial) {
+        return
+      }
+
+      if (typeof window === 'undefined') {
         return
       }
 
       Router.ready(() => {
         // Router.ready ensures that Router.router is defined
-        store.dispatch(onLocationChanged(locationFromUrl(Router.asPath), 'REPLACE'))
+        const { pathname } = window.location
+        store.dispatch(onLocationChanged(locationFromUrl(pathname), 'REPLACE'))
       })
 
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ConnectedRouter.ts
+++ b/src/ConnectedRouter.ts
@@ -30,11 +30,12 @@ const createConnectedRouter = (structure: Structure): React.FC<ConnectedRouterPr
     const inTimeTravelling = useRef(false)
 
     function trackRouteComplete(): void {
-      isTimeTravelEnabled.current = --ongoingRouteChanges.current <= 0
+      ongoingRouteChanges.current = Math.max(ongoingRouteChanges.current - 1, 0)
+      isTimeTravelEnabled.current = ongoingRouteChanges.current === 0
     }
 
     function trackRouteStart(): void {
-      isTimeTravelEnabled.current = ++ongoingRouteChanges.current <= 0
+      isTimeTravelEnabled.current = ++ongoingRouteChanges.current === 0
     }
 
     useEffect(() => {


### PR DESCRIPTION
When I initially open a static page (haven't tested it with SSR),  the `trackRouteStart` isn't called but the `trackRouteComplete` is. Because of this `ongoingRouteChanges.current` becomes `-1` and the lib thinks that `the isTimeTravelEnabled.current` is always true.  
This leads to a bug when you change a page, store changes, triggers `listenStoreChanges` and the `locationMismatch` sends you to the previous page.  

Well, I've fixed only the couse not a reason, but it's always better to have this kind of check, because if the counter becomes negative, then there's definitely something wrong.  
But I'd still recommend you to figure out why trackRouteStart doesn't work on the first load.