### PR TITLE
Make doc more copypastable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Or [yarn](https://yarnpkg.com/):
 
 ```js
 // store/configure-store.js
+import { createStore, applyMiddleware, combineReducers } from 'redux'
+import { createRouterMiddleware, initialRouterState, routerReducer } from 'connected-next-router'
 import { format } from 'url'
-import { applyMiddleware, compose, createStore, combineReducers } from 'redux'
-import { routerReducer, createRouterMiddleware, initialRouterState } from 'connected-next-router'
-import { createWrapper } from 'next-redux-wrapper'
+import { HYDRATE, createWrapper } from 'next-redux-wrapper'
+import Router from 'next/router'
 
 const rootReducer = combineReducers({
   ...reducers,
@@ -69,11 +70,10 @@ const routerMiddleware = createRouterMiddleware({
 export const initStore = (context) => {
   const routerMiddleware = createRouterMiddleware()
   const { asPath, pathname, query } = context.ctx || Router.router || {};
-  let initialState = {}
+  let initialState
   if (asPath) {
     const url = format({ pathname, query })
     initialState = {
-      ...initialState,
       router: initialRouterState(url, asPath)
     }
   }

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Or [yarn](https://yarnpkg.com/):
 
 ```js
 // store/configure-store.js
-import { createStore, applyMiddleware, combineReducers } from 'redux'
+import { applyMiddleware, compose, createStore, combineReducers } from 'redux'
 import { createRouterMiddleware, initialRouterState, routerReducer } from 'connected-next-router'
 import { format } from 'url'
-import { HYDRATE, createWrapper } from 'next-redux-wrapper'
+import { createWrapper } from 'next-redux-wrapper'
 import Router from 'next/router'
 
 const rootReducer = combineReducers({

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Or [yarn](https://yarnpkg.com/):
 
 ```js
 // store/configure-store.js
+import { format } from 'url';
 import { applyMiddleware, compose, createStore, combineReducers } from 'redux'
 import { routerReducer, createRouterMiddleware, initialRouterState } from 'connected-next-router'
 import { createWrapper } from 'next-redux-wrapper'
@@ -68,10 +69,11 @@ const routerMiddleware = createRouterMiddleware({
 export const initStore = (context) => {
   const routerMiddleware = createRouterMiddleware()
   const { asPath, pathname, query } = context.ctx || Router.router || {};
-  let initialState
+  let initialState = {}
   if (asPath) {
     const url = format({ pathname, query })
     initialState = {
+      ...initialState,
       router: initialRouterState(url, asPath)
     }
   }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or [yarn](https://yarnpkg.com/):
 
 ```js
 // store/configure-store.js
-import { format } from 'url';
+import { format } from 'url'
 import { applyMiddleware, compose, createStore, combineReducers } from 'redux'
 import { routerReducer, createRouterMiddleware, initialRouterState } from 'connected-next-router'
 import { createWrapper } from 'next-redux-wrapper'


### PR DESCRIPTION
I didn't know what's the `format` function was, so it was quite a problem to find it out. I believe that it's better to have code examples that anyone can copy and use immediately without thinking.